### PR TITLE
fix: implement _transform noop required in node v0.11+

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,11 @@ function FreeLoaderStream(options) {
 
 FreeLoaderStream.prototype.name = 'FreeLoaderStream';
 
+FreeLoaderStream.prototype._transform = function(chunk, encoding, cb) {
+  // derived classes will explicitly 'push' data on the 'request' event
+  cb(null, null);
+};
+
 FreeLoaderStream.prototype.end = function() {
   // should be overriden
 }


### PR DESCRIPTION
Prior to this fix a 'not implemented' error would be thrown when running node v0.12 or v4.0.

Fixes #1 
